### PR TITLE
Add inner folder to repro bug

### DIFF
--- a/inner/package.json
+++ b/inner/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "test2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "stylelint": "13.13.1"
+  }
+}

--- a/inner/test2.js
+++ b/inner/test2.js
@@ -1,0 +1,7 @@
+const testFunction = (a, b) => {
+  if (a == b) {
+    console.log("equal");
+  } else {
+    console.log("not equal");
+  }
+};


### PR DESCRIPTION
File has to be inside a nested folder that _also_ has `node_modules` _but_ does not have `eslint` in it.
In this case, `eslint` from the top most `node_modules` folder is not found. Run `npm i` in both root and `inner` folder
and open `test2.js` to repro.
